### PR TITLE
Persist current word index

### DIFF
--- a/main.html
+++ b/main.html
@@ -278,6 +278,7 @@
                 correctlySpelledWords: [],
                 unlockedRewards: [],
                 companionType: 'pikachu', // Pikachu is the buddy from the start!
+                currentWordIndex: 0,
             });
             const [isProcessing, setIsProcessing] = React.useState(false);
             const [lastFeedback, setLastFeedback] = React.useState(null);
@@ -295,6 +296,13 @@
                         ...savedProgress,
                         companionType: 'pikachu',
                     });
+                    const idx = savedProgress.currentWordIndex || 0;
+                    setCurrentWordIndex(idx);
+                    if (savedProgress.correctlySpelledWords && savedProgress.correctlySpelledWords.length >= WORD_LIST.length) {
+                        setGamePhase(GamePhase.ALL_WORDS_COMPLETED);
+                    } else if (idx > 0 || savedProgress.xp > 0) {
+                        setTimeout(() => startNextWord(), 100);
+                    }
                 }
 
                 // speech recognition removed
@@ -347,6 +355,8 @@
                 if (currentWordIndex >= WORD_LIST.length) {
                     setGamePhase(GamePhase.ALL_WORDS_COMPLETED);
                     speakText("Wow, you've spelled all the words! You're a spelling superstar!");
+                    setCurrentWordIndex(0);
+                    setUserProgress(prev => ({ ...prev, currentWordIndex: 0 }));
                     return;
                 }
                 const word = WORD_LIST[currentWordIndex];
@@ -360,7 +370,7 @@
             // --- Start game handler ---
             const handleStartGame = () => {
                 setCurrentWordIndex(0);
-                const initialProgress = { xp: 0, correctlySpelledWords: [], unlockedRewards: [], companionType: 'pikachu' };
+                const initialProgress = { xp: 0, correctlySpelledWords: [], unlockedRewards: [], companionType: 'pikachu', currentWordIndex: 0 };
                 setUserProgress(initialProgress);
                 localStorage.setItem('spellAndLearnProgress', JSON.stringify(initialProgress));
                 setLastUnlockedReward(null);
@@ -441,7 +451,11 @@
 
             // --- Advance to next word after feedback ---
             const advanceToNextWordFromFeedback = () => {
-                setCurrentWordIndex(prev => prev + 1);
+                setCurrentWordIndex(prev => {
+                    const next = prev + 1;
+                    setUserProgress(p => ({ ...p, currentWordIndex: next }));
+                    return next;
+                });
                 setTimeout(() => {
                     startNextWord();
                 }, 100);


### PR DESCRIPTION
## Summary
- add `currentWordIndex` to saved progress
- restore index and resume saved game
- keep index updated when advancing or restarting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68428f71a27c83328f32dc45d592e31a